### PR TITLE
LPS-57465 JSONContentTypeResponse should set the content type from application/json to text/plain

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/filters/jsoncontenttype/JSONContentTypeResponse.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/jsoncontenttype/JSONContentTypeResponse.java
@@ -35,7 +35,7 @@ public class JSONContentTypeResponse extends HttpServletResponseWrapper {
 		if (StringUtil.equalsIgnoreCase(
 				contentType, ContentTypes.APPLICATION_JSON)) {
 
-			contentType = ContentTypes.TEXT_JAVASCRIPT;
+			contentType = ContentTypes.TEXT_PLAIN;
 		}
 
 		super.setContentType(contentType);


### PR DESCRIPTION
Hey @migue 

Could you please check this pull?

In IE when a .json or .js file is returned with a mimeResponse, an open or save prompt window will be opened. In case of a .js file even a syntax error message is displayed if the response contains a simple {success: true} message.

In LPS-33187 the JSONContentTypeFilter and JSONContentTypeResponse classes were introduced, which are responsible for turning application/json content types into text/javascript, but it didn't solved the issue described in that LPS:
https://issues.liferay.com/browse/LPS-33187

However, I found that setting content type to text/plain instead of text/javascript achieves the desired effect in that no open or save window will opened in the browser.

Please let me know what you think.

Thanks,
István