### PR TITLE
LPS-57557 WAB modules include WEB-INF/tld/liferay-aui.tld file. However, the web.xml maps the location of the tld file to /WEB-INF/tld/aui.tld but it should point to /WEB-INF/tld/liferay-aui.tld

### DIFF
--- a/portal-impl/src/com/liferay/portal/tools/deploy/BaseDeployer.java
+++ b/portal-impl/src/com/liferay/portal/tools/deploy/BaseDeployer.java
@@ -1237,7 +1237,7 @@ public class BaseDeployer implements AutoDeployer, Deployer {
 			sb.append("<taglib>");
 			sb.append("<taglib-uri>http://liferay.com/tld/aui</taglib-uri>");
 			sb.append("<taglib-location>");
-			sb.append("/WEB-INF/tld/aui.tld");
+			sb.append("/WEB-INF/tld/liferay-aui.tld");
 			sb.append("</taglib-location>");
 			sb.append("</taglib>");
 		}


### PR DESCRIPTION
Buenas Migue,

En el web.xml que se genera dentro de los módulos WAB (wiki, bookmarks) está lo siguiente

```
	<jsp-config>
		<taglib>
			<taglib-uri>http://liferay.com/tld/aui</taglib-uri>
			<taglib-location>/WEB-INF/tld/aui.tld</taglib-location>
		</taglib>
		<taglib>
			<taglib-uri>http://java.sun.com/portlet_2_0</taglib-uri>
			<taglib-location>/WEB-INF/tld/liferay-portlet.tld</taglib-location>
		</taglib>
		<taglib>
			<taglib-uri>http://liferay.com/tld/security</taglib-uri>
			<taglib-location>/WEB-INF/tld/liferay-security.tld</taglib-location>
		</taglib>
		<taglib>
			<taglib-uri>http://liferay.com/tld/theme</taglib-uri>
			<taglib-location>/WEB-INF/tld/liferay-theme.tld</taglib-location>
		</taglib>
		<taglib>
			<taglib-uri>http://liferay.com/tld/ui</taglib-uri>
			<taglib-location>/WEB-INF/tld/liferay-ui.tld</taglib-location>
		</taglib>
		<taglib>
			<taglib-uri>http://liferay.com/tld/util</taglib-uri>
			<taglib-location>/WEB-INF/tld/liferay-util.tld</taglib-location>
		</taglib>
	</jsp-config>

```

Sin embargo, para http://liferay.com/tld/aui no existe el tld asociado, ya que no se llama aui.tld si no liferay-aui.tld

Parece que Brian hizo cambios en LPS-55800 donde renombró ficheros de aui.tld a liferay-aui.tld (28 de julio) así que parece que tiene que estar relacionado con eso.

Te lo envío a ti para que lo eches un vistazo :)

Gracias!