### PR TITLE
LPS-64080 Use which instead of whereis.

### DIFF
--- a/tools/db-upgrade/run.sh
+++ b/tools/db-upgrade/run.sh
@@ -20,7 +20,7 @@ showUsage() {
 CLASSPATH=""
 DEBUG="false"
 DEBUG_OPTS="-agentlib:jdwp=transport=dt_socket,address=9009,server=y,suspend=n"
-JAVA_BIN="$(whereis java)"
+JAVA_BIN="$(which java)"
 JAVA_OPTS="-Xmx2048m -XX:MaxPermSize=384m"
 STD_IN=0
 


### PR DESCRIPTION
Hey Miguel!

Could not run the db upgrade on my Ubuntu box due to the "whereis" output. This change made it work, and I guess it also works on Mac OS X.

Thanks!