### PR TITLE
LPS-68290

### DIFF
--- a/portal-impl/src/com/liferay/portal/increment/BufferedIncreasableEntry.java
+++ b/portal-impl/src/com/liferay/portal/increment/BufferedIncreasableEntry.java
@@ -17,6 +17,8 @@ package com.liferay.portal.increment;
 import com.liferay.portal.kernel.concurrent.IncreasableEntry;
 import com.liferay.portal.kernel.increment.Increment;
 
+import java.util.Arrays;
+
 import org.aopalliance.intercept.MethodInvocation;
 
 /**
@@ -50,7 +52,10 @@ public class BufferedIncreasableEntry<K, T>
 
 	@Override
 	public String toString() {
-		return _methodInvocation.toString();
+		Object[] arguments = _methodInvocation.getArguments();
+
+		return _methodInvocation.toString() + " - " +
+			Arrays.toString(arguments);
 	}
 
 	private final MethodInvocation _methodInvocation;

--- a/portal-impl/src/com/liferay/portal/increment/BufferedIncrementRunnable.java
+++ b/portal-impl/src/com/liferay/portal/increment/BufferedIncrementRunnable.java
@@ -67,8 +67,9 @@ public class BufferedIncrementRunnable implements Runnable {
 			}
 			catch (Throwable t) {
 				_log.error(
-					"Unable to write buffered increment value to the database",
-					t);
+					"Unable to write buffered increment value to the " +
+					"database: " + bufferedIncreasableEntry,
+				t);
 			}
 
 			if (_bufferedIncrementConfiguration.isStandbyEnabled()) {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-68290

We have a customer with some errors related to this async method, it seems there are some invalid data:
```
04:38:37,141 ERROR [BufferedIncreament-AssetEntryLocalService.incrementViewCounter(long,String,long,int)-1][DefaultTransactionExecutor:93] Application exception overridden by commit exception
org.springframework.jdbc.UncategorizedSQLException: Hibernate flushing: Could not execute JDBC batch update; uncategorized SQLException for SQL [update AssetEntry set groupId=?, companyId=?, userId=?, userName=?, createDate=?, modifiedDate=?, classNameId=?, classPK=?, classUuid=?, classTypeId=?, visible=?, startDate=?, endDate=?, publishDate=?, expirationDate=?, mimeType=?, title=?, description=?, summary=?, url=?, layoutUuid=?, height=?, width=?, priority=?, viewCount=? where entryId=?]; SQL state [99999]; error code [17268]; Año fuera de rango.; nested exception is java.sql.BatchUpdateException: Año fuera de rango.
```

In order to be able to diagnose the root cause of the issue, we need to write the method name and parameters.

Before my change:
```
01:58:15,088 ERROR [com.liferay.portal.increment.BufferedIncrementRunnable:68] Unable to write buffered increment value to the database
```

After my change:
```
00:26:28,865 ERROR [com.liferay.portal.increment.BufferedIncrementRunnable:68] Unable to write buffered increment value to the database: com.liferay.portlet.asset.service.AssetEntryLocalService.incrementViewCounter(long,java.lang.String,long,int)@com.liferay.portlet.asset.service.impl.AssetEntryLocalServiceImpl - [10117, com.liferay.portlet.journal.model.JournalArticle, 49514, 1]
```

This change will allow to support to diagnose similar issues in other customers