### PR TITLE
FileUtil.encodeSafeFileName() can be lossy, if the original file name includes reserved characters

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/FileImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/FileImpl.java
@@ -1110,7 +1110,10 @@ public class FileImpl implements com.liferay.portal.kernel.util.File {
 	};
 
 	private static final String[] _SAFE_FILE_NAME_2 = {
-		"_AMP_", "_CP_", "_OP_", "_SEM_"
+		PropsValues.DL_STORE_FILE_IMPL_SAFE_FILE_NAME_2_AMPERSAND,
+		PropsValues.DL_STORE_FILE_IMPL_SAFE_FILE_NAME_2_CLOSE_PARENTHESIS,
+		PropsValues.DL_STORE_FILE_IMPL_SAFE_FILE_NAME_2_OPEN_PARENTHESIS,
+		PropsValues.DL_STORE_FILE_IMPL_SAFE_FILE_NAME_2_SEMICOLON
 	};
 
 	private static final Log _log = LogFactoryUtil.getLog(FileImpl.class);

--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -560,6 +560,14 @@ public class PropsValues {
 
 	public static final String DL_STORE_ANTIVIRUS_IMPL = PropsUtil.get(PropsKeys.DL_STORE_ANTIVIRUS_IMPL);
 
+	public static final String DL_STORE_FILE_IMPL_SAFE_FILE_NAME_2_AMPERSAND = PropsUtil.get(PropsKeys.DL_STORE_FILE_IMPL_SAFE_FILE_NAME_2_AMPERSAND);
+
+	public static final String DL_STORE_FILE_IMPL_SAFE_FILE_NAME_2_CLOSE_PARENTHESIS = PropsUtil.get(PropsKeys.DL_STORE_FILE_IMPL_SAFE_FILE_NAME_2_CLOSE_PARENTHESIS);
+
+	public static final String DL_STORE_FILE_IMPL_SAFE_FILE_NAME_2_OPEN_PARENTHESIS = PropsUtil.get(PropsKeys.DL_STORE_FILE_IMPL_SAFE_FILE_NAME_2_OPEN_PARENTHESIS);
+
+	public static final String DL_STORE_FILE_IMPL_SAFE_FILE_NAME_2_SEMICOLON = PropsUtil.get(PropsKeys.DL_STORE_FILE_IMPL_SAFE_FILE_NAME_2_SEMICOLON);
+
 	public static String DL_STORE_IMPL = PropsUtil.get(PropsKeys.DL_STORE_IMPL);
 
 	public static String DL_WEBDAV_SUBSTITUTION_CHAR = PropsUtil.get(PropsKeys.DL_WEBDAV_SUBSTITUTION_CHAR);

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -8489,6 +8489,19 @@
     #dl.store.antivirus.impl=com.liferay.portlet.documentlibrary.antivirus.ClamAntivirusScannerImpl
 
     #
+    # These properties define the replacement strings for certain characters,
+    # to get safe file names. They are used in com.liferay.portal.util.FileImpl
+    # See LPS-69122 .
+    #
+    # You should not modify these properties unless you are completely certain
+    # that no file has been stored using previous values.
+    #
+    dl.store.file.impl.safe.file.name.2.ampersand=_AMP_
+    dl.store.file.impl.safe.file.name.2.close.parenthesis=_CP_
+    dl.store.file.impl.safe.file.name.2.open.parenthesis=_OP_
+    dl.store.file.impl.safe.file.name.2.semicolon=_SEM_
+
+    #
     # Set the name of a class that implements
     # com.liferay.document.library.kernel.store.Store. The
     # document library server will use this to persist documents.

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -731,6 +731,14 @@ public interface PropsKeys {
 
 	public static final String DL_STORE_ANTIVIRUS_IMPL = "dl.store.antivirus.impl";
 
+	public static final String DL_STORE_FILE_IMPL_SAFE_FILE_NAME_2_AMPERSAND = "dl.store.file.impl.safe.file.name.2.ampersand";
+
+	public static final String DL_STORE_FILE_IMPL_SAFE_FILE_NAME_2_CLOSE_PARENTHESIS = "dl.store.file.impl.safe.file.name.2.close.parenthesis";
+
+	public static final String DL_STORE_FILE_IMPL_SAFE_FILE_NAME_2_OPEN_PARENTHESIS = "dl.store.file.impl.safe.file.name.2.open.parenthesis";
+
+	public static final String DL_STORE_FILE_IMPL_SAFE_FILE_NAME_2_SEMICOLON = "dl.store.file.impl.safe.file.name.2.semicolon";
+
 	public static final String DL_STORE_IMPL = "dl.store.impl";
 
 	public static final String DL_SUBFOLDERS_VISIBLE = "dl.subfolders.visible";


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-69122