### PR TITLE
LPS-68616 Adding missing upgrade indexes

### DIFF
--- a/modules/apps/collaboration/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/upgrade/v1_0_0/UpgradeCompanyId.java
+++ b/modules/apps/collaboration/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/upgrade/v1_0_0/UpgradeCompanyId.java
@@ -22,10 +22,22 @@ import com.liferay.portal.kernel.upgrade.BaseUpgradeCompanyId;
 public class UpgradeCompanyId extends BaseUpgradeCompanyId {
 
 	@Override
+	protected void doUpgrade() throws Exception {
+		super.doUpgrade();
+
+		String template = "create index IX_13319367 on WikiPageResource " +
+			"(uuid_[$COLUMN_LENGTH:75$], companyId);";
+
+		runSQLTemplateString(template, false, false);
+	}
+
+	@Override
 	protected TableUpdater[] getTableUpdaters() {
 		return new TableUpdater[] {
 			new TableUpdater("WikiPageResource", "WikiNode", "nodeId")
 		};
 	}
+
+
 
 }

--- a/modules/apps/collaboration/wiki/wiki-service/src/main/resources/com/liferay/wiki/internal/upgrade/v1_0_0/dependencies/update.sql
+++ b/modules/apps/collaboration/wiki/wiki-service/src/main/resources/com/liferay/wiki/internal/upgrade/v1_0_0/dependencies/update.sql
@@ -1,3 +1,5 @@
 alter table WikiPageResource add groupId LONG;
 
+create unique index IX_F705C7A9 on WikiPageResource (uuid_[$COLUMN_LENGTH:75$], groupId);
+
 COMMIT_TRANSACTION;

--- a/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/resources/com/liferay/calendar/upgrade/v1_0_6/dependencies/update.sql
+++ b/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/resources/com/liferay/calendar/upgrade/v1_0_6/dependencies/update.sql
@@ -1,3 +1,5 @@
 alter table CalendarBooking add recurringCalendarBookingId LONG null;
 
+create index IX_14ADC52E on CalendarBooking (recurringCalendarBookingId);
+
 update CalendarBooking set recurringCalendarBookingId = calendarBookingId;

--- a/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v1_0_0/UpgradeCompanyId.java
+++ b/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v1_0_0/UpgradeCompanyId.java
@@ -22,6 +22,16 @@ import com.liferay.portal.kernel.upgrade.BaseUpgradeCompanyId;
 public class UpgradeCompanyId extends BaseUpgradeCompanyId {
 
 	@Override
+	protected void doUpgrade() throws Exception {
+		super.doUpgrade();
+
+		String template = "create index IX_DB81EB42 on DDMStorageLink " +
+			"(uuid_[$COLUMN_LENGTH:75$], companyId);";
+
+		runSQLTemplateString(template, false, false);
+	}
+
+	@Override
 	protected TableUpdater[] getTableUpdaters() {
 		return new TableUpdater[] {
 			new TableUpdater("DDMStorageLink", "DDMStructure", "structureId"),

--- a/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/com/liferay/dynamic/data/mapping/internal/upgrade/v1_0_0/dependencies/update.sql
+++ b/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/com/liferay/dynamic/data/mapping/internal/upgrade/v1_0_0/dependencies/update.sql
@@ -13,12 +13,20 @@ create table DDMDataProviderInstance (
 	type_ VARCHAR(75) null
 );
 
+create index IX_DB54A6E5 on DDMDataProviderInstance (companyId);
+create index IX_1333A2A7 on DDMDataProviderInstance (groupId);
+create index IX_C903C097 on DDMDataProviderInstance (uuid_[$COLUMN_LENGTH:75$], companyId);
+create unique index IX_B4E180D9 on DDMDataProviderInstance (uuid_[$COLUMN_LENGTH:75$], groupId);
+
 create table DDMDataProviderInstanceLink (
 	dataProviderInstanceLinkId LONG not null primary key,
 	companyId LONG,
 	dataProviderInstanceId LONG,
 	structureId LONG
 );
+
+create unique index IX_8C878342 on DDMDataProviderInstanceLink (dataProviderInstanceId, structureId);
+create index IX_CB823541 on DDMDataProviderInstanceLink (structureId);
 
 alter table DDMStructure add versionUserId LONG;
 alter table DDMStructure add versionUserName VARCHAR(75) null;
@@ -41,6 +49,12 @@ create table DDMStructureLayout (
 	definition TEXT null
 );
 
+create unique index IX_B7158C0A on DDMStructureLayout (structureVersionId);
+create index IX_A90FF72A on DDMStructureLayout (uuid_[$COLUMN_LENGTH:75$], companyId);
+create unique index IX_C9A0402C on DDMStructureLayout (uuid_[$COLUMN_LENGTH:75$], groupId);
+
+create unique index IX_E43143A3 on DDMStructureLink (classNameId, classPK, structureId);
+
 create table DDMStructureVersion (
 	structureVersionId LONG not null primary key,
 	groupId LONG,
@@ -62,6 +76,9 @@ create table DDMStructureVersion (
 	statusDate DATE null
 );
 
+create index IX_17B3C96C on DDMStructureVersion (structureId, status);
+create unique index IX_64C3C42 on DDMStructureVersion (structureId, version[$COLUMN_LENGTH:75$]);
+
 alter table DDMTemplate add versionUserId LONG;
 alter table DDMTemplate add versionUserName VARCHAR(75) null;
 alter table DDMTemplate add resourceClassNameId LONG;
@@ -78,6 +95,9 @@ create table DDMTemplateLink (
 	classPK LONG,
 	templateId LONG
 );
+
+create unique index IX_6F3B3E9C on DDMTemplateLink (classNameId, classPK);
+create index IX_85278170 on DDMTemplateLink (templateId);
 
 create table DDMTemplateVersion (
 	templateVersionId LONG not null primary key,
@@ -99,5 +119,8 @@ create table DDMTemplateVersion (
 	statusByUserName VARCHAR(75) null,
 	statusDate DATE null
 );
+
+create index IX_66382FC6 on DDMTemplateVersion (templateId, status);
+create unique index IX_8854A128 on DDMTemplateVersion (templateId, version[$COLUMN_LENGTH:75$]);
 
 COMMIT_TRANSACTION;

--- a/modules/apps/foundation/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/upgrade/v1_0_0/UpgradeSchema.java
+++ b/modules/apps/foundation/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/upgrade/v1_0_0/UpgradeSchema.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.background.task.internal.upgrade.v1_0_0;
+
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.LoggingTimer;
+import com.liferay.portal.kernel.util.StringUtil;
+
+/**
+ * @author Miguel Pastor
+ */
+public class UpgradeSchema extends UpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		try (LoggingTimer loggingTimer = new LoggingTimer()) {
+			String template = StringUtil.read(
+				UpgradeSchema.class.getResourceAsStream(
+					"dependencies/update.sql"));
+
+			runSQLTemplateString(template, false, false);
+		}
+	}
+
+}

--- a/modules/apps/foundation/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/upgrade/BackgroundTaskServiceUpgrade.java
+++ b/modules/apps/foundation/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/upgrade/BackgroundTaskServiceUpgrade.java
@@ -15,6 +15,7 @@
 package com.liferay.portal.background.task.upgrade;
 
 import com.liferay.portal.background.task.internal.upgrade.v1_0_0.UpgradeBackgroundTask;
+import com.liferay.portal.background.task.internal.upgrade.v1_0_0.UpgradeSchema;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 
 import org.osgi.service.component.annotations.Component;
@@ -28,7 +29,11 @@ public class BackgroundTaskServiceUpgrade implements UpgradeStepRegistrator {
 	@Override
 	public void register(Registry registry) {
 		registry.register(
-			"com.liferay.portal.background.task.service", "0.0.1", "1.0.0",
+			"com.liferay.portal.background.task.service", "0.0.1", "0.0.2",
+			new UpgradeSchema());
+
+		registry.register(
+			"com.liferay.portal.background.task.service", "0.0.2", "1.0.0",
 			new UpgradeBackgroundTask());
 	}
 

--- a/modules/apps/foundation/portal-background-task/portal-background-task-service/src/main/resources/com/liferay/portal/background/task/internal/upgrade/v1_0_0/dependencies/update.sql
+++ b/modules/apps/foundation/portal-background-task/portal-background-task-service/src/main/resources/com/liferay/portal/background/task/internal/upgrade/v1_0_0/dependencies/update.sql
@@ -1,0 +1,3 @@
+create index IX_FBF5FAA2 on BackgroundTask (completed);
+
+COMMIT_TRANSACTION;

--- a/modules/apps/web-experience/journal/.gitrepo
+++ b/modules/apps/web-experience/journal/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = e5aa5fe1acec0e5835c2e1d4ff043d012e528cd3
+	commit = 07c3ee021ae7a8ba4aa9781e9aac6d7fc63f728d
 	mode = pull
-	parent = 99dc84c207b676435f2de4f5aa03946a98006116
+	parent = 088dcdb1fecc6539bdb70093f265d85d5754a0f4
 	remote = git@github.com:liferay/com-liferay-journal.git

--- a/modules/apps/web-experience/journal/.gitrepo
+++ b/modules/apps/web-experience/journal/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 227a0b43e983e18335c272e1f7f1126fc024c463
+	commit = e5aa5fe1acec0e5835c2e1d4ff043d012e528cd3
 	mode = pull
-	parent = f772344873aa2a00c430e86e3f8515f3df56ab8f
+	parent = 99dc84c207b676435f2de4f5aa03946a98006116
 	remote = git@github.com:liferay/com-liferay-journal.git

--- a/modules/apps/web-experience/journal/gradle.properties
+++ b/modules/apps/web-experience/journal/gradle.properties
@@ -1,2 +1,2 @@
-com.liferay.source.formatter.version=1.0.343
+com.liferay.source.formatter.version=1.0.348
 project.path.prefix=:apps:web-experience:journal

--- a/modules/apps/web-experience/journal/journal-api/src/main/java/com/liferay/journal/util/comparator/FolderArticleArticleIdComparator.java
+++ b/modules/apps/web-experience/journal/journal-api/src/main/java/com/liferay/journal/util/comparator/FolderArticleArticleIdComparator.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.journal.util.comparator;
+
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.portal.kernel.util.OrderByComparator;
+
+/**
+ * @author Eudaldo
+ */
+public class FolderArticleArticleIdComparator
+	extends OrderByComparator<Object> {
+
+	public static final String ORDER_BY_ASC = "articleId ASC";
+
+	public static final String ORDER_BY_DESC = "articleId DESC";
+
+	public static final String[] ORDER_BY_FIELDS = {"articleId"};
+
+	public FolderArticleArticleIdComparator() {
+		this(false);
+	}
+
+	public FolderArticleArticleIdComparator(boolean ascending) {
+		_ascending = ascending;
+	}
+
+	@Override
+	public int compare(Object object1, Object object2) {
+		int value = 0;
+
+		if ((object1 instanceof JournalArticle) &&
+			(object2 instanceof JournalArticle)) {
+
+			String articleId1 = ((JournalArticle)object1).getArticleId();
+			String articleId2 = ((JournalArticle)object2).getArticleId();
+
+			value = articleId1.compareTo(articleId2);
+		}
+		else if (object1 instanceof JournalArticle) {
+			value = -1;
+		}
+		else if (object2 instanceof JournalArticle) {
+			value = 1;
+		}
+
+		if (_ascending) {
+			return value;
+		}
+		else {
+			return -value;
+		}
+	}
+
+	@Override
+	public String getOrderBy() {
+		if (_ascending) {
+			return ORDER_BY_ASC;
+		}
+		else {
+			return ORDER_BY_DESC;
+		}
+	}
+
+	@Override
+	public String[] getOrderByFields() {
+		return ORDER_BY_FIELDS;
+	}
+
+	@Override
+	public boolean isAscending() {
+		return _ascending;
+	}
+
+	private final boolean _ascending;
+
+}

--- a/modules/apps/web-experience/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/portlet/configuration/icon/EditJournalArticlePortletConfigurationIcon.java
+++ b/modules/apps/web-experience/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/portlet/configuration/icon/EditJournalArticlePortletConfigurationIcon.java
@@ -17,8 +17,14 @@ package com.liferay.journal.content.web.internal.portlet.configuration.icon;
 import com.liferay.journal.content.web.constants.JournalContentPortletKeys;
 import com.liferay.journal.content.web.internal.display.context.JournalContentDisplayContext;
 import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIcon;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.WebKeys;
 
 import java.util.ResourceBundle;
 
@@ -63,6 +69,15 @@ public class EditJournalArticlePortletConfigurationIcon
 
 	@Override
 	public boolean isShow(PortletRequest portletRequest) {
+		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		Group group = themeDisplay.getScopeGroup();
+
+		if (group.hasStagingGroup() && _STAGING_LIVE_GROUP_LOCKING_ENABLED) {
+			return false;
+		}
+
 		JournalContentDisplayContext journalContentDisplayContext =
 			getJournalContentDisplayContext(portletRequest, null);
 
@@ -81,5 +96,9 @@ public class EditJournalArticlePortletConfigurationIcon
 	public void setServletContext(ServletContext servletContext) {
 		super.setServletContext(servletContext);
 	}
+
+	private static final boolean _STAGING_LIVE_GROUP_LOCKING_ENABLED =
+		GetterUtil.getBoolean(
+			PropsUtil.get(PropsKeys.STAGING_LIVE_GROUP_LOCKING_ENABLED));
 
 }

--- a/modules/apps/web-experience/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_1_0/UpgradeDocumentLibraryTypeContent.java
+++ b/modules/apps/web-experience/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_1_0/UpgradeDocumentLibraryTypeContent.java
@@ -137,13 +137,10 @@ public class UpgradeDocumentLibraryTypeContent extends UpgradeProcess {
 
 		long groupId = GetterUtil.getLong(parts[2]);
 
-		String uuid = null;
+		String uuid = parts[5];
 
 		if (parts.length == 5) {
 			uuid = getUuidByDocumentLibraryURLWithoutUuid(parts);
-		}
-		else {
-			uuid = parts[5];
 		}
 
 		return _dlAppLocalService.getFileEntryByUuidAndGroupId(uuid, groupId);

--- a/modules/apps/web-experience/journal/journal-service/src/main/java/com/liferay/journal/search/JournalArticleIndexer.java
+++ b/modules/apps/web-experience/journal/journal-service/src/main/java/com/liferay/journal/search/JournalArticleIndexer.java
@@ -498,7 +498,7 @@ public class JournalArticleIndexer
 			articleId = TrashUtil.getOriginalTitle(articleId);
 		}
 
-		document.addKeyword(Field.ARTICLE_ID, articleId);
+		document.addKeywordSortable(Field.ARTICLE_ID, articleId);
 
 		document.addKeyword(Field.LAYOUT_UUID, journalArticle.getLayoutUuid());
 		document.addKeyword(

--- a/modules/apps/web-experience/journal/journal-web/src/main/java/com/liferay/journal/web/dynamic/data/mapping/util/JournalFeedSelectStructureDDMDisplay.java
+++ b/modules/apps/web-experience/journal/journal-web/src/main/java/com/liferay/journal/web/dynamic/data/mapping/util/JournalFeedSelectStructureDDMDisplay.java
@@ -16,8 +16,10 @@ package com.liferay.journal.web.dynamic.data.mapping.util;
 
 import com.liferay.dynamic.data.mapping.util.DDMDisplay;
 import com.liferay.journal.constants.JournalPortletKeys;
+import com.liferay.portal.kernel.util.Portal;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Eudaldo Alonso
@@ -41,6 +43,11 @@ public class JournalFeedSelectStructureDDMDisplay extends JournalDDMDisplay {
 	@Override
 	public boolean isShowConfirmSelectStructure() {
 		return false;
+	}
+
+	@Reference(unbind = "-")
+	protected void setPortal(Portal portal) {
+		this.portal = portal;
 	}
 
 }

--- a/modules/apps/web-experience/journal/journal-web/src/main/java/com/liferay/journal/web/dynamic/data/mapping/util/JournalFilterStructuresDDMDisplay.java
+++ b/modules/apps/web-experience/journal/journal-web/src/main/java/com/liferay/journal/web/dynamic/data/mapping/util/JournalFilterStructuresDDMDisplay.java
@@ -16,8 +16,10 @@ package com.liferay.journal.web.dynamic.data.mapping.util;
 
 import com.liferay.dynamic.data.mapping.util.DDMDisplay;
 import com.liferay.journal.constants.JournalPortletKeys;
+import com.liferay.portal.kernel.util.Portal;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Eudaldo Alonso
@@ -41,6 +43,11 @@ public class JournalFilterStructuresDDMDisplay extends JournalDDMDisplay {
 	@Override
 	public boolean isShowConfirmSelectStructure() {
 		return false;
+	}
+
+	@Reference(unbind = "-")
+	protected void setPortal(Portal portal) {
+		this.portal = portal;
 	}
 
 }

--- a/modules/apps/web-experience/journal/journal-web/src/main/java/com/liferay/journal/web/dynamic/data/mapping/util/JournalSelectStructureRestrictionsDDMDisplay.java
+++ b/modules/apps/web-experience/journal/journal-web/src/main/java/com/liferay/journal/web/dynamic/data/mapping/util/JournalSelectStructureRestrictionsDDMDisplay.java
@@ -16,8 +16,10 @@ package com.liferay.journal.web.dynamic.data.mapping.util;
 
 import com.liferay.dynamic.data.mapping.util.DDMDisplay;
 import com.liferay.journal.constants.JournalPortletKeys;
+import com.liferay.portal.kernel.util.Portal;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Eudaldo Alonso
@@ -42,6 +44,11 @@ public class JournalSelectStructureRestrictionsDDMDisplay
 	@Override
 	public boolean isShowConfirmSelectStructure() {
 		return false;
+	}
+
+	@Reference(unbind = "-")
+	protected void setPortal(Portal portal) {
+		this.portal = portal;
 	}
 
 }

--- a/modules/apps/web-experience/journal/journal-web/src/main/java/com/liferay/journal/web/dynamic/data/mapping/util/JournalSelectStructuresDDMDisplay.java
+++ b/modules/apps/web-experience/journal/journal-web/src/main/java/com/liferay/journal/web/dynamic/data/mapping/util/JournalSelectStructuresDDMDisplay.java
@@ -17,8 +17,10 @@ package com.liferay.journal.web.dynamic.data.mapping.util;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.util.DDMDisplay;
 import com.liferay.journal.constants.JournalPortletKeys;
+import com.liferay.portal.kernel.util.Portal;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Eudaldo Alonso
@@ -48,6 +50,11 @@ public class JournalSelectStructuresDDMDisplay extends JournalDDMDisplay {
 	@Override
 	public boolean isShowAddStructureButton() {
 		return false;
+	}
+
+	@Reference(unbind = "-")
+	protected void setPortal(Portal portal) {
+		this.portal = portal;
 	}
 
 }

--- a/modules/apps/web-experience/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
+++ b/modules/apps/web-experience/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
@@ -516,6 +516,10 @@ public class JournalDisplayContext {
 		return _orderByType;
 	}
 
+	public String[] getOrderColumns() {
+		return new String[] {"display-date", "modified-date", "title"};
+	}
+
 	public PortletURL getPortletURL() throws PortalException {
 		PortletURL portletURL = _liferayPortletResponse.createRenderURL();
 

--- a/modules/apps/web-experience/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
+++ b/modules/apps/web-experience/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
@@ -31,6 +31,7 @@ import com.liferay.journal.service.JournalArticleServiceUtil;
 import com.liferay.journal.service.JournalFolderLocalServiceUtil;
 import com.liferay.journal.service.JournalFolderServiceUtil;
 import com.liferay.journal.util.JournalConverter;
+import com.liferay.journal.util.comparator.FolderArticleArticleIdComparator;
 import com.liferay.journal.util.comparator.FolderArticleDisplayDateComparator;
 import com.liferay.journal.util.comparator.FolderArticleModifiedDateComparator;
 import com.liferay.journal.util.comparator.FolderArticleTitleComparator;
@@ -56,6 +57,7 @@ import com.liferay.portal.kernel.portlet.PortalPreferences;
 import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
 import com.liferay.portal.kernel.portlet.PortletURLUtil;
 import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.DocumentImpl;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Hits;
 import com.liferay.portal.kernel.search.Indexer;
@@ -517,7 +519,18 @@ public class JournalDisplayContext {
 	}
 
 	public String[] getOrderColumns() {
-		return new String[] {"display-date", "modified-date", "title"};
+		JournalWebConfiguration journalWebConfiguration =
+			(JournalWebConfiguration)_request.getAttribute(
+				JournalWebConfiguration.class.getName());
+
+		String[] orderColumns =
+			new String[] {"display-date", "modified-date", "title"};
+
+		if (!journalWebConfiguration.journalArticleForceAutogenerateId()) {
+			orderColumns = ArrayUtil.append(orderColumns, "id");
+		}
+
+		return orderColumns;
 	}
 
 	public PortletURL getPortletURL() throws PortalException {
@@ -742,6 +755,11 @@ public class JournalDisplayContext {
 				if (Objects.equals(getOrderByCol(), "display-date")) {
 					sort = new Sort("displayDate", Sort.LONG_TYPE, orderByAsc);
 				}
+				else if (Objects.equals(getOrderByCol(), "id")) {
+					sort = new Sort(
+						DocumentImpl.getSortableFieldName(Field.ARTICLE_ID),
+						Sort.STRING_TYPE, !orderByAsc);
+				}
 				else if (Objects.equals(getOrderByCol(), "modified-date")) {
 					sort = new Sort(
 						Field.MODIFIED_DATE, Sort.LONG_TYPE, orderByAsc);
@@ -844,6 +862,10 @@ public class JournalDisplayContext {
 			if (Objects.equals(getOrderByCol(), "display-date")) {
 				folderOrderByComparator =
 					new FolderArticleDisplayDateComparator(orderByAsc);
+			}
+			else if (Objects.equals(getOrderByCol(), "id")) {
+				folderOrderByComparator = new FolderArticleArticleIdComparator(
+					orderByAsc);
 			}
 			else if (Objects.equals(getOrderByCol(), "modified-date")) {
 				folderOrderByComparator =

--- a/modules/apps/web-experience/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/template/JournalTemplateHandler.java
+++ b/modules/apps/web-experience/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/template/JournalTemplateHandler.java
@@ -171,6 +171,10 @@ public class JournalTemplateHandler extends BaseDDMTemplateHandler {
 	}
 
 	private JournalContent _journalContent;
+
+	@Reference
+	private Portal _portal;
+
 	private final TemplateVariableCodeHandler _templateVariableCodeHandler =
 		new DDMTemplateVariableCodeHandler(
 			JournalTemplateHandler.class.getClassLoader(),
@@ -181,6 +185,4 @@ public class JournalTemplateHandler extends BaseDDMTemplateHandler {
 					"image", "link-to-page"
 				}));
 
-	@Reference
-	private Portal _portal;
 }

--- a/modules/apps/web-experience/journal/journal-web/src/main/resources/META-INF/resources/toolbar.jsp
+++ b/modules/apps/web-experience/journal/journal-web/src/main/resources/META-INF/resources/toolbar.jsp
@@ -87,7 +87,7 @@ String searchContainerId = ParamUtil.getString(request, "searchContainerId");
 		<liferay-frontend:management-bar-sort
 			orderByCol="<%= journalDisplayContext.getOrderByCol() %>"
 			orderByType="<%= journalDisplayContext.getOrderByType() %>"
-			orderColumns='<%= new String[] {"display-date", "modified-date", "title"} %>'
+			orderColumns="<%= journalDisplayContext.getOrderColumns() %>"
 			portletURL="<%= journalDisplayContext.getPortletURL() %>"
 		/>
 	</liferay-frontend:management-bar-filters>

--- a/modules/apps/web-experience/journal/journal-web/src/main/resources/META-INF/resources/view_entries.jsp
+++ b/modules/apps/web-experience/journal/journal-web/src/main/resources/META-INF/resources/view_entries.jsp
@@ -162,6 +162,13 @@ String searchContainerId = ParamUtil.getString(request, "searchContainerId");
 						</liferay-ui:search-container-column-text>
 					</c:when>
 					<c:otherwise>
+						<c:if test="<%= !journalWebConfiguration.journalArticleForceAutogenerateId() %>">
+							<liferay-ui:search-container-column-text
+								name="id"
+								value="<%= HtmlUtil.escape(curArticle.getArticleId()) %>"
+							/>
+						</c:if>
+
 						<liferay-ui:search-container-column-jsp
 							cssClass="table-cell-content"
 							href="<%= previewArticleContentURL %>"
@@ -295,6 +302,13 @@ String searchContainerId = ParamUtil.getString(request, "searchContainerId");
 						</liferay-ui:search-container-column-text>
 					</c:when>
 					<c:otherwise>
+						<c:if test="<%= !journalWebConfiguration.journalArticleForceAutogenerateId() %>">
+							<liferay-ui:search-container-column-text
+								name="id"
+								value="<%= HtmlUtil.escape(String.valueOf(curFolder.getFolderId())) %>"
+							/>
+						</c:if>
+
 						<liferay-ui:search-container-column-text
 							cssClass="table-cell-content"
 							href="<%= rowURL.toString() %>"


### PR DESCRIPTION
Hey @migue,

Por favor, echa un vistazo a los dos últimos commits, no puedo usar runSQL() porque los índices contienen la longitud de uno de lo campos:
uuid_[$COLUMN_LENGTH:75$]

Y el runSQL() no normaliza eso dando error de sintaxis. He usado el método runSQLTemplateString() porque llama al método que normaliza la longitud de los campos en índices:
com.liferay.portal.dao.db.BaseDB#applyMaxStringIndexLengthLimitation

Hay alguna otra opción como:
- Crear un nuevo runSQL() sólo para índices que lo primero que haga sea llamar a applyMaxStringIndexLengthLimitation(). Algo así como runIndexSQL() o runSQL(..., boolean addIndex)

Dime cómo lo ves y hacemos lo más conveniente.

Un saludo.